### PR TITLE
fix: change log format

### DIFF
--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -10,7 +10,7 @@ quarkus.micrometer.export.prometheus.path=/prometheus
 quarkus.micrometer.export.prometheus.enabled=true
 metrics.micrometer.enabled=true
 
-quarkus.log.console.format=[%d{yyyy-MM-dd'T'HH:mm:ss.SSS}] [%-5p] [request_id=%X{x-request-id}] [deployment_session_id=%X{sessionId}] [tenant_id=%X{tenantId}] [thread=%t] [class=%c{1}] [phase=%X{phase}] [name=%X{resource-name}] [kind=%X{kind}] [subKind=%X{sub-kind}] %s%e%n
+quarkus.log.console.format=[%d{yyyy-MM-dd'T'HH:mm:ss.SSS}] [%-5p] [request_id=%X{x-request-id}] [tenant_id=%X{tenantId}] [thread=%t] [class=%c{1}] [deployment_session_id=%X{sessionId}] [phase=%X{phase}] [name=%X{resource-name}] [kind=%X{kind}] [subKind=%X{sub-kind}] %s%e%n
 quarkus.http.limits.max-header-size=${http.buffer.header.max.size:10240}
 
 quarkus.rest-client.mesh-client-v3.url=http://control-plane:8080


### PR DESCRIPTION
Logging guide requires following format: `time, level, request_id, tenant_id, thread, class, other fields`
Currently, `deployment_session_id` appears in between `request_id` and `tenant_id`. Moved it to the end so that it appears after the `class` field.